### PR TITLE
Fixing issue when a record in ES doesn't exist

### DIFF
--- a/spring-data-jest/src/main/java/com/github/vanroy/springdata/jest/mapper/DefaultJestResultsMapper.java
+++ b/spring-data-jest/src/main/java/com/github/vanroy/springdata/jest/mapper/DefaultJestResultsMapper.java
@@ -68,7 +68,7 @@ public class DefaultJestResultsMapper implements JestResultsMapper {
 	}
 
 	public <T> T mapResult(DocumentResult response, Class<T> clazz) {
-		T result = mapEntity(response.getJsonObject().get("_source").toString(), clazz);
+		T result = mapEntity(response.getSourceAsString(), clazz);
 		if (result != null) {
 			setPersistentEntityId(result, response.getId(), clazz);
 		}


### PR DESCRIPTION
Hi Julien

I was doing some tests and I made a call to get a non existent record in ES noticed that a null pointer exception was thrown in line 71 (DefaultJestMapper)
```java
T result = mapEntity(response.getJsonObject().get("_source").toString(), class);
```
changing it to:
```java
 T result = mapEntity(response.getSourceAsString(), class);
```
resolves the issues. I took a look at the code from spring.  Repository.exists(...) which returns a boolean actually throws a null pointer exception.  

Hope this PR works for you.  

Cheers
Amin