### PR TITLE
check some results to prevent NullPointerExceptions

### DIFF
--- a/spring-data-jest/src/main/java/com/github/vanroy/springdata/jest/JestElasticsearchTemplate.java
+++ b/spring-data-jest/src/main/java/com/github/vanroy/springdata/jest/JestElasticsearchTemplate.java
@@ -497,6 +497,9 @@ public class JestElasticsearchTemplate implements ElasticsearchOperations, Appli
 
 	public <T> Page<T> queryForPage(StringQuery query, Class<T> clazz, JestSearchResultMapper mapper) {
 		SearchResult response = executeSearch(query, prepareSearch(query, clazz).query(query.getSource()));
+		if (!response.isSucceeded()) {
+			throw new ElasticsearchException("couldn't query for page [message: " + response.getErrorMessage() + "]");
+		}
 		return mapper.mapResults(response, clazz, query.getPageable());
 	}
 
@@ -626,6 +629,9 @@ public class JestElasticsearchTemplate implements ElasticsearchOperations, Appli
 		}
 
 		CountResult result = execute(countRequestBuilder.build());
+		if (!result.isSucceeded()) {
+			throw new ElasticsearchException("couldn't count result of query [message: " + result.getErrorMessage() + "]");
+		}
 		return result.getCount().longValue();
 	}
 


### PR DESCRIPTION
in our system we have to generate indicies on the fly which get the same entity class mapped to. This also means that basically every query can fail with an index_not_found_exception.

There might be even more places where those exceptions might occur, but those handle all known operations on spring data repositories with auto generated query methods using the @Query annotation