### PR TITLE
Remove log error when throwing exception

### DIFF
--- a/spring-data-jest/src/main/java/com/github/vanroy/springdata/jest/JestElasticsearchTemplate.java
+++ b/spring-data-jest/src/main/java/com/github/vanroy/springdata/jest/JestElasticsearchTemplate.java
@@ -1095,7 +1095,6 @@ public class JestElasticsearchTemplate implements ElasticsearchOperations, Appli
 				if(acceptNotFound && isSuccessfulResponse(result.getResponseCode())) {
 					logger.debug(errorMessage);
 				} else {
-					logger.error(errorMessage);
 					throw new ElasticsearchException(errorMessage);
 				}
 			}


### PR DESCRIPTION
We could perhaps  keep this at info level, or maybe even warning if others might be relying on it. 
The error logging is problematic, as it might not be an error from the callers perspective. 
In my use-case I use versioning  to achieve optimistic locking so the operation is can be retried and will succeed after the exception. I monitor application logs for errors, so this one needlessly gets my attention. The exception is logged in full in the caller that implements the retries, but only at DEBUG level.  