### PR TITLE
Custom http configurer integration

### DIFF
--- a/spring-boot-starter-data-jest/src/test/java/com/github/vanroy/springboot/autoconfigure/data/jest/ElasticsearchJestAutoConfigurationWithCustomHttpConfigurerTest.java
+++ b/spring-boot-starter-data-jest/src/test/java/com/github/vanroy/springboot/autoconfigure/data/jest/ElasticsearchJestAutoConfigurationWithCustomHttpConfigurerTest.java
@@ -1,0 +1,57 @@
+package com.github.vanroy.springboot.autoconfigure.data.jest;
+
+
+import com.github.vanroy.springboot.autoconfigure.data.jest.repositories.ProductRepository;
+import io.searchbox.client.JestClient;
+import io.searchbox.client.http.JestHttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.Configurable;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration;
+import org.springframework.boot.autoconfigure.elasticsearch.jest.HttpClientConfigBuilderCustomizer;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = ElasticsearchJestAutoConfigurationWithCustomHttpConfigurerTest.SpringBootStarterDataJestApplication.class)
+public class ElasticsearchJestAutoConfigurationWithCustomHttpConfigurerTest {
+
+    @Autowired
+    private JestClient jestClient;
+
+
+    @Test
+    public void should_jest_auto_configuration_have_custom_httpbuilder() {
+        RequestConfig config = ((Configurable) ((JestHttpClient) jestClient).getHttpClient()).getConfig();
+
+        int connectTimeout = config.getConnectTimeout();
+
+        assertThat(connectTimeout, is(3551));
+    }
+
+    @SpringBootApplication(exclude = {
+            ElasticsearchAutoConfiguration.class,
+            ElasticsearchDataAutoConfiguration.class,
+            ElasticsearchJestAWSAutoConfiguration.class
+    },
+            scanBasePackageClasses = ProductRepository.class)
+    public static class SpringBootStarterDataJestApplication {
+
+        @Bean
+        public HttpClientConfigBuilderCustomizer customizer() {
+            return httpBuilder ->
+                    httpBuilder
+                            .connTimeout(3551);
+
+        }
+
+    }
+}


### PR DESCRIPTION
Hi @VanRoy, I left the original ```ElasticsearchJestAutoConfigurationTest``` so as to prove that the new configuration code was optional. New test checks that the connection time out was actually updated.

Let me know if this is ok.

Thanks