### PR TITLE
Trying to fix this exception raised when I try to save any document in …

### DIFF
--- a/spring-data-jest/src/main/java/com/github/vanroy/springdata/jest/JestElasticsearchTemplate.java
+++ b/spring-data-jest/src/main/java/com/github/vanroy/springdata/jest/JestElasticsearchTemplate.java
@@ -858,13 +858,13 @@ public class JestElasticsearchTemplate implements ElasticsearchOperations, Appli
 
 	@Override
 	public void refresh(String indexName) {
-		execute(new Refresh.Builder().addIndex(indexName).refresh(true).build());
+		execute(new Refresh.Builder().addIndex(indexName).build());
 	}
 
 	@Override
 	public <T> void refresh(Class<T> clazz) {
 		ElasticsearchPersistentEntity persistentEntity = getPersistentEntityFor(clazz);
-		execute(new Refresh.Builder().addIndex(persistentEntity.getIndexName()).refresh(true).build());
+		execute(new Refresh.Builder().addIndex(persistentEntity.getIndexName()).build());
 	}
 
 	@Override


### PR DESCRIPTION
…elasticsearch:

org.springframework.data.elasticsearch.ElasticsearchException: Cannot execute jest action , response code : 400 , error : {"root_cause":[{"type":"illegal_argument_exception","reason":"request [/xico/_refresh] contains unrecognized parameter: [refresh]"}],"type":"illegal_argument_exception","reason":"request [/xico/_refresh] contains unrecognized parameter: [refresh]"} , message : null
	at com.github.vanroy.springdata.jest.JestElasticsearchTemplate.execute(JestElasticsearchTemplate.java:1099) ~[spring-data-jest-2.3.1.RELEASE.jar:na]
	at com.github.vanroy.springdata.jest.JestElasticsearchTemplate.execute(JestElasticsearchTemplate.java:1084) ~[spring-data-jest-2.3.1.RELEASE.jar:na]
	at com.github.vanroy.springdata.jest.JestElasticsearchTemplate.refresh(JestElasticsearchTemplate.java:861) ~[spring-data-jest-2.3.1.RELEASE.jar:na]
	at org.springframework.data.elasticsearch.repository.support.AbstractElasticsearchRepository.save(AbstractElasticsearchRepository.java:148) ~[spring-data-elasticsearch-2.1.1.RELEASE.jar:na]

The _refresh operator does not suports "?refresh=true" parameter.

regards,