### PR TITLE
Upgrade to latest Jest version 5.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Versions
 
 |   spring data jest |      spring boot     | spring data elasticsearch |  jest  | elasticsearch |
 |:------------------:|:--------------------:|:-------------------------:|:------:|:-------------:|
+|   3.1.1-SNAPSHOT   |         2.0.0        |       3.0.5.RELEASE       |  5.3.3 |      5.5.0    |
 |   3.1.0.RELEASE    |         2.0.0        |       3.0.5.RELEASE       |  5.3.2 |      5.5.0    |
 |   3.0.0.RELEASE    |       2.0.0.M4       |       3.0.0.RELEASE       |  5.3.2 |      5.5.0    |
 |   2.3.1.RELEASE    |         1.5.x        |       2.1.0.RELEASE       |  2.0.4 |      2.4.4    |

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.github.vanroy</groupId>
 	<artifactId>spring-data-jest-build</artifactId>
-	<version>3.1.0.RELEASE</version>
+	<version>3.1.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Jest Build</name>
@@ -50,7 +50,7 @@
 		<springboot>2.0.0.RELEASE</springboot>
 		<spring>5.0.4.RELEASE</spring>
 		<springdataes>3.0.5.RELEASE</springdataes>
-		<jest>5.3.2</jest>
+		<jest>5.3.3</jest>
 		<gson>2.8.0</gson>
 		<awssigning>0.0.16</awssigning>
 		<springcloudaws>1.2.1.RELEASE</springcloudaws>

--- a/spring-boot-sample-data-jest-aws/pom.xml
+++ b/spring-boot-sample-data-jest-aws/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.vanroy</groupId>
         <artifactId>spring-data-jest-build</artifactId>
-        <version>3.1.0.RELEASE</version>
+        <version>3.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/spring-boot-sample-data-jest/pom.xml
+++ b/spring-boot-sample-data-jest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.vanroy</groupId>
         <artifactId>spring-data-jest-build</artifactId>
-        <version>3.1.0.RELEASE</version>
+        <version>3.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/spring-boot-starter-data-jest/pom.xml
+++ b/spring-boot-starter-data-jest/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.vanroy</groupId>
         <artifactId>spring-data-jest-build</artifactId>
-        <version>3.1.0.RELEASE</version>
+        <version>3.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/spring-data-jest/pom.xml
+++ b/spring-data-jest/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.vanroy</groupId>
         <artifactId>spring-data-jest-build</artifactId>
-        <version>3.1.0.RELEASE</version>
+        <version>3.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/spring-data-jest/src/main/java/com/github/vanroy/springdata/jest/JestElasticsearchTemplate.java
+++ b/spring-data-jest/src/main/java/com/github/vanroy/springdata/jest/JestElasticsearchTemplate.java
@@ -631,9 +631,9 @@ public class JestElasticsearchTemplate implements ElasticsearchOperations, Appli
 
 		Assert.notNull(indexName, "No index defined for Query");
 
-		Count.Builder countRequestBuilder = new Count.Builder().addIndex(Arrays.asList(indexName));
+		Count.Builder countRequestBuilder = new Count.Builder().addIndices(Arrays.asList(indexName));
 		if (types != null) {
-			countRequestBuilder.addType(Arrays.asList(types));
+			countRequestBuilder.addTypes(Arrays.asList(types));
 		}
 		return countRequestBuilder;
 	}
@@ -913,8 +913,8 @@ public class JestElasticsearchTemplate implements ElasticsearchOperations, Appli
 		}
 
 		Search.Builder search = new Search.Builder(searchSourceBuilder.toString()).
-				addType(criteriaQuery.getTypes()).
-				addIndex(criteriaQuery.getIndices()).
+				addTypes(criteriaQuery.getTypes()).
+				addIndices(criteriaQuery.getIndices()).
 				setParameter(Parameters.SIZE, criteriaQuery.getPageable().getPageSize()).
 				setParameter(Parameters.SCROLL, scrollTimeInMillis + "ms");
 
@@ -931,8 +931,8 @@ public class JestElasticsearchTemplate implements ElasticsearchOperations, Appli
 		}
 
 		Search.Builder search = new Search.Builder(searchSourceBuilder.toString()).
-				addType(searchQuery.getTypes()).
-				addIndex(searchQuery.getIndices()).
+				addTypes(searchQuery.getTypes()).
+				addIndices(searchQuery.getIndices()).
 				setParameter(Parameters.SIZE, searchQuery.getPageable().getPageSize()).
 				setParameter(Parameters.SCROLL, scrollTimeInMillis + "ms");
 
@@ -1313,8 +1313,8 @@ public class JestElasticsearchTemplate implements ElasticsearchOperations, Appli
 		Search.Builder search = new Search.Builder(request.toString());
 		if (query != null) {
 			search.
-					addType(query.getTypes()).
-					addIndex(query.getIndices()).
+					addTypes(query.getTypes()).
+					addIndices(query.getIndices()).
 					setSearchType(SearchType.valueOf(query.getSearchType().name()));
 		}
 

--- a/spring-data-jest/src/test/java/com/github/vanroy/springdata/jest/JestElasticsearchTemplateTests.java
+++ b/spring-data-jest/src/test/java/com/github/vanroy/springdata/jest/JestElasticsearchTemplateTests.java
@@ -1199,7 +1199,7 @@ public class JestElasticsearchTemplateTests {
 		elasticsearchTemplate.createIndex(entity);
 		elasticsearchTemplate.putMapping(entity);
 		// when
-		Map<String, Map<String, Map<String, String>>> mapping = elasticsearchTemplate.getMapping(entity);
+		Map<String, Map<String, Map<String, Object>>> mapping = elasticsearchTemplate.getMapping(entity);
 		// then
 		assertThat(mapping.containsKey("properties"), is(true));
 		assertThat(mapping.get("properties").containsKey("message"), is(true));


### PR DESCRIPTION
Using gradle the latest dependency version is selected:

```
io.searchbox:jest:5.3.2 -> 5.3.3
\--- com.github.vanroy:spring-data-jest:3.1.0.RELEASE
     \--- com.github.vanroy:spring-boot-starter-data-jest:3.1.0.RELEASE
```
There are some renamed methods within this version which causes errors e.g.
```
java.lang.NoSuchMethodError: io.searchbox.core.Count$Builder.addIndex(Ljava/util/Collection;)Ljava/lang/Object;
```
I have changed related code to match Jest 5.3.3.