### PR TITLE
Add searchQuery is passed creating scroll

### DIFF
--- a/spring-data-jest/src/main/java/com/github/vanroy/springdata/jest/JestElasticsearchTemplate.java
+++ b/spring-data-jest/src/main/java/com/github/vanroy/springdata/jest/JestElasticsearchTemplate.java
@@ -926,6 +926,9 @@ public class JestElasticsearchTemplate implements ElasticsearchOperations, Appli
 		Assert.notNull(searchQuery.getTypes(), "No type define for Query");
 		Assert.notNull(searchQuery.getPageable(), "Query.pageable is required for scan & scroll");
 
+		QueryBuilder elasticsearchQuery = searchQuery.getQuery();
+		searchSourceBuilder.query(elasticsearchQuery != null ? elasticsearchQuery : QueryBuilders.matchAllQuery());
+
 		if (searchQuery.getFilter() != null) {
 			searchSourceBuilder.postFilter(searchQuery.getFilter());
 		}

--- a/spring-data-jest/src/test/java/com/github/vanroy/springdata/jest/JestElasticsearchTemplateTests.java
+++ b/spring-data-jest/src/test/java/com/github/vanroy/springdata/jest/JestElasticsearchTemplateTests.java
@@ -844,12 +844,14 @@ public class JestElasticsearchTemplateTests {
 	public void shouldReturnResultsWithScanAndScrollForGivenSearchQuery() {
 		//given
 		List<IndexQuery> entities = createSampleEntitiesWithMessage("Test message", 30);
+		entities.addAll(createSampleEntitiesWithMessage("Filtered out message", 30));
 		// when
 		elasticsearchTemplate.bulkIndex(entities);
 		elasticsearchTemplate.refresh(SampleEntity.class);
 		// then
 
-		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).withIndices(INDEX_NAME)
+		SearchQuery searchQuery = new NativeSearchQueryBuilder()
+				.withQuery(QueryBuilders.matchQuery("message", "Test")).withIndices(INDEX_NAME)
 				.withTypes(TYPE_NAME).withPageable(PageRequest.of(0, 10)).build();
 
 		ScrolledPage<SampleEntity> scroll = (ScrolledPage<SampleEntity>) elasticsearchTemplate.startScroll(1000, searchQuery, SampleEntity.class);


### PR DESCRIPTION
Embrace searchQuery parameter in order to fix that scroll of
search query always returns all data of given indices without
considering parameter.