### PR TITLE
Provide ability to opt-in to Jest's idle connection reaper

### DIFF
--- a/spring-boot-starter-data-jest/src/main/java/com/github/vanroy/springboot/autoconfigure/data/jest/ElasticsearchJestAutoConfiguration.java
+++ b/spring-boot-starter-data-jest/src/main/java/com/github/vanroy/springboot/autoconfigure/data/jest/ElasticsearchJestAutoConfiguration.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import io.searchbox.client.JestClient;
@@ -110,6 +111,7 @@ public class ElasticsearchJestAutoConfiguration implements DisposableBean {
 		HttpClientConfig.Builder builder = new HttpClientConfig.Builder(uri)
 			.maxTotalConnection(properties.getMaxTotalConnection())
 			.defaultMaxTotalConnectionPerRoute(properties.getDefaultMaxTotalConnectionPerRoute())
+			.maxConnectionIdleTime(properties.getMaxConnectionIdleTime(), TimeUnit.MILLISECONDS)
 			.readTimeout(properties.getReadTimeout())
 			.multiThreaded(properties.getMultiThreaded());
 

--- a/spring-boot-starter-data-jest/src/main/java/com/github/vanroy/springboot/autoconfigure/data/jest/ElasticsearchJestProperties.java
+++ b/spring-boot-starter-data-jest/src/main/java/com/github/vanroy/springboot/autoconfigure/data/jest/ElasticsearchJestProperties.java
@@ -18,6 +18,7 @@ public class ElasticsearchJestProperties {
 	private int maxTotalConnection = 50;
 	private int defaultMaxTotalConnectionPerRoute = 50;
 	private int readTimeout = 5000;
+	private long maxConnectionIdleTime = 0L; // Idle connection reaping disabled by default
 	private Boolean multiThreaded = true;
 	
 	/**
@@ -75,6 +76,14 @@ public class ElasticsearchJestProperties {
 
 	public void setReadTimeout(int readTimeout) {
 		this.readTimeout = readTimeout;
+	}
+
+	public long getMaxConnectionIdleTime() {
+		return maxConnectionIdleTime;
+	}
+
+	public void setMaxConnectionIdleTime(long maxConnectionIdleTime) {
+		this.maxConnectionIdleTime = maxConnectionIdleTime;
 	}
 
 	public Boolean getMultiThreaded() {


### PR DESCRIPTION
Expose ability to override `maxConnectionIdleTime` via configuration properties. Set a default value which disables the idle connection reaper if no such property is found. Consume the property in `ElasticsearchJestAutoConfiguration` where the `JestClient` is created.