### PR TITLE
Issue #77 - Upgrade to latest signing library v0.0.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For specific case of AWS ES Domain (with Request Signing) add this dependency:
 <dependency>
     <groupId>vc.inreach.aws</groupId>
     <artifactId>aws-signing-request-interceptor</artifactId>
-    <version>0.0.16</version>
+    <version>0.0.21</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 		<springdataes>3.0.0.RELEASE</springdataes>
 		<jest>5.3.2</jest>
 		<gson>2.8.0</gson>
-		<awssigning>0.0.16</awssigning>
+		<awssigning>0.0.21</awssigning>
 		<springcloudaws>1.2.1.RELEASE</springcloudaws>
 		<jna>4.2.2</jna>
 		<hamcrest>1.3</hamcrest>


### PR DESCRIPTION
Upgrading references to the AWS signing library to the latest version to prevent issues connecting to AWS ES service. Re: #77 