### PR TITLE
Problem with AutoConfiguration Order

### DIFF
--- a/spring-boot-starter-data-jest/src/main/java/com/github/vanroy/springboot/autoconfigure/data/jest/ElasticsearchJestAWSAutoConfiguration.java
+++ b/spring-boot-starter-data-jest/src/main/java/com/github/vanroy/springboot/autoconfigure/data/jest/ElasticsearchJestAWSAutoConfiguration.java
@@ -30,7 +30,10 @@ import vc.inreach.aws.request.AWSSigningRequestInterceptor;
  */
 @Configuration
 @ConditionalOnClass(AWSSigner.class)
-@AutoConfigureAfter(name = "org.springframework.cloud.aws.autoconfigure.context.ContextRegionProviderAutoConfiguration")
+@AutoConfigureAfter(name = {
+        "org.springframework.cloud.aws.autoconfigure.context.ContextRegionProviderAutoConfiguration",
+        "org.springframework.cloud.aws.autoconfigure.context.ContextCredentialsAutoConfiguration"
+})
 public class ElasticsearchJestAWSAutoConfiguration {
 
 	private static final String AWS_SERVICE = "es";


### PR DESCRIPTION
Added ContextCredentialsAutoConfiguration to ElasticsearchJestAWSAutoConfiguration @AutoConfigureAfter name list
to evaluate AWSCredentialProvider bean after ContextCredentialsAutoConfiguration