### PR TITLE
add node failover capacity

### DIFF
--- a/spring-boot-starter-data-jest/src/main/java/com/github/vanroy/springboot/autoconfigure/data/jest/ElasticsearchJestAutoConfiguration.java
+++ b/spring-boot-starter-data-jest/src/main/java/com/github/vanroy/springboot/autoconfigure/data/jest/ElasticsearchJestAutoConfiguration.java
@@ -114,7 +114,9 @@ public class ElasticsearchJestAutoConfiguration implements DisposableBean {
 			.defaultMaxTotalConnectionPerRoute(properties.getDefaultMaxTotalConnectionPerRoute())
 			.maxConnectionIdleTime(properties.getMaxConnectionIdleTime(), TimeUnit.MILLISECONDS)
 			.readTimeout(properties.getReadTimeout())
-			.multiThreaded(properties.getMultiThreaded());
+			.multiThreaded(properties.getMultiThreaded())
+			.defaultSchemeForDiscoveredNodes(properties.getDefaultSchemeForDiscoveredNodes())
+			.discoveryEnabled(Boolean.parseBoolean(properties.getDiscoveryEnabled()));
 
 		if (StringUtils.hasText(this.properties.getUsername())) {
 			builder.defaultCredentials(this.properties.getUsername(), this.properties.getPassword());

--- a/spring-boot-starter-data-jest/src/main/java/com/github/vanroy/springboot/autoconfigure/data/jest/ElasticsearchJestProperties.java
+++ b/spring-boot-starter-data-jest/src/main/java/com/github/vanroy/springboot/autoconfigure/data/jest/ElasticsearchJestProperties.java
@@ -17,7 +17,8 @@ public class ElasticsearchJestProperties {
 	private String password;
 
 	private String awsRegion;
-
+	private String defaultSchemeForDiscoveredNodes = "https";
+	private String discoveryEnabled;
 	private int maxTotalConnection = 50;
 	private int defaultMaxTotalConnectionPerRoute = 50;
 	private int readTimeout = 5000;
@@ -108,7 +109,24 @@ public class ElasticsearchJestProperties {
 	public void setAwsRegion(String awsRegion) {
 		this.awsRegion = awsRegion;
 	}
-	
+
+	public String getDefaultSchemeForDiscoveredNodes() {
+		return defaultSchemeForDiscoveredNodes;
+	}
+
+
+	public void setDefaultSchemeForDiscoveredNodes(String defaultSchemeForDiscoveredNodes) {
+		this.defaultSchemeForDiscoveredNodes = defaultSchemeForDiscoveredNodes;
+	}
+
+	public String getDiscoveryEnabled() {
+		return discoveryEnabled;
+	}
+
+	public void setDiscoveryEnabled(String discoveryEnabled) {
+		this.discoveryEnabled = discoveryEnabled;
+	}
+
 	public static class Proxy {
 
 		/**


### PR DESCRIPTION
This PR enable node failover in cluster context.
Change defaultSchemeForDiscoveredNodes to "https" by default for production ready deployment