### PR TITLE
Fix for Issue #122: Modify the startRecord calculation to use the Pageable.getOffset method

### DIFF
--- a/spring-data-jest/src/main/java/com/github/vanroy/springdata/jest/JestElasticsearchTemplate.java
+++ b/spring-data-jest/src/main/java/com/github/vanroy/springdata/jest/JestElasticsearchTemplate.java
@@ -1150,7 +1150,7 @@ public class JestElasticsearchTemplate implements ElasticsearchOperations, Appli
 		int startRecord = 0;
 
 		if (query.getPageable() != null && query.getPageable().isPaged()) {
-			startRecord = query.getPageable().getPageNumber() * query.getPageable().getPageSize();
+			startRecord = (int) query.getPageable().getOffset();
 			searchSourceBuilder.size(query.getPageable().getPageSize());
 		}
 		searchSourceBuilder.from(startRecord);


### PR DESCRIPTION
The previous startRecord calculation used the Pageable.getPageNumber and Pageable.getPageSize methods to retrieve the start record.  This works fine for the standard PageRequest but can cause a problem for custom Pageable implementations that do not use a true "page".

Since the current calculation is the same as the Pageable.getOffset method's calculation, this PR adjusts the code to use the Pageable.getOffset method.