### PR TITLE
Respect custom highlight builder from SearchQuery object.

### DIFF
--- a/spring-data-jest/src/main/java/com/github/vanroy/springdata/jest/JestElasticsearchTemplate.java
+++ b/spring-data-jest/src/main/java/com/github/vanroy/springdata/jest/JestElasticsearchTemplate.java
@@ -1273,7 +1273,11 @@ public class JestElasticsearchTemplate implements ElasticsearchOperations, Appli
 			}
 		}
 
-		if (searchQuery.getHighlightFields() != null) {
+		if (searchQuery.getHighlightBuilder() != null) {
+
+			searchSourceBuilder.highlighter(searchQuery.getHighlightBuilder());
+
+		} else if (searchQuery.getHighlightFields() != null) {
 			HighlightBuilder highlighter = SearchSourceBuilder.highlight();
 			for (HighlightBuilder.Field highlightField : searchQuery.getHighlightFields()) {
 				highlighter.field(highlightField);


### PR DESCRIPTION
## Symptom

Current JestElasticsearchTemplate doesn't respect custom highlight from SearchQuery.

## Problem

The template re-creates highlight builder when it detects highlight fields been set.


## Solution

Respect the highlight builder from SearchQuery object and support the old re-creation way for backward compatibility.